### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ logs
 compile.sh
 newcommit.txt
 functions.txt
+dependencies/__pycache__/aalib.cpython-38.pyc


### PR DESCRIPTION
Added dependencies/__pycache__/aalib.cpython-38.pyc to .gitignore because that file seems to be generated when running view.py for the first time.